### PR TITLE
Change version to 0.1.0

### DIFF
--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module DangerSwiftlint
-  VERSION = '1.0.0'.freeze
+  VERSION = '0.1.0'.freeze
 end


### PR DESCRIPTION
Got a bit hasty during development. Let's start with 0.1.0 and see if this actually works for anybody. Easy enough to bump back to 1.0.0 later.